### PR TITLE
Support schematics mocking

### DIFF
--- a/protobuf_schematics/types.py
+++ b/protobuf_schematics/types.py
@@ -16,6 +16,10 @@ class EnumType(StringType):
         return self.enum_class[value]
 
     def to_primitive(self, value, context=None):
+        try:
+            assert isinstance(value, self.enum_class)
+        except AssertionError:
+            raise TypeError('EnumType require a proper enum to convert to primitive.')
         return value.name
 
     def _mock(self, context=None):

--- a/protobuf_schematics/types.py
+++ b/protobuf_schematics/types.py
@@ -2,6 +2,7 @@ import random
 from base64 import b64decode, b64encode
 from random import choice
 
+import six
 from schematics.types import StringType
 
 
@@ -28,9 +29,15 @@ class EnumType(StringType):
 
 class BytesType(StringType):
     def to_native(self, value, context=None):
-        if isinstance(value, bytes):
-            return value
-        return b64decode(value)
+        if six.PY2:
+            try:
+                return value.decode('base64')
+            except Exception:
+                return value
+        else:
+            if isinstance(value, bytes):
+                return value
+            return b64decode(value)
 
     def to_primitive(self, value, context=None):
         return b64encode(value).decode('ascii')

--- a/protobuf_schematics/types.py
+++ b/protobuf_schematics/types.py
@@ -1,4 +1,6 @@
+import random
 from base64 import b64decode, b64encode
+from random import choice
 
 from schematics.types import StringType
 
@@ -9,15 +11,27 @@ class EnumType(StringType):
         super(EnumType, self).__init__(**kwargs)
 
     def to_native(self, value, context=None):
+        if value in self.enum_class:
+            return value
         return self.enum_class[value]
 
     def to_primitive(self, value, context=None):
         return value.name
 
+    def _mock(self, context=None):
+        return choice(list(self.enum_class))
+
 
 class BytesType(StringType):
     def to_native(self, value, context=None):
+        if isinstance(value, bytes):
+            return value
         return b64decode(value)
 
     def to_primitive(self, value, context=None):
         return b64encode(value).decode('ascii')
+
+    def _mock(self, context=None):
+        # nasty hack to get the should be size
+        size = len(super(BytesType, self)._mock(context))
+        return bytes(random.getrandbits(8) for _ in range(size))

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ requirements = [
     'protobuf',
     'schematics',
     'typing',
+    'six',
 ]
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,64 @@
+from enum import Enum
+
+import binascii
+import pytest
+from schematics import Model
+
+from protobuf_schematics.types import EnumType, BytesType
+
+
+class TestEnumType(object):
+    class SomeEnum(Enum):
+        A = 1
+        B = 2
+        C = 3
+
+    class OtherEnum(Enum):
+        A = 1
+
+    field = EnumType(SomeEnum)
+
+    def test_to_native(self):
+        assert self.field.to_native(self.SomeEnum.A) == self.SomeEnum.A
+        assert self.field.to_native('B') == self.SomeEnum.B
+        with pytest.raises(KeyError):
+            self.field.to_native(self.SomeEnum.A.value)
+        with pytest.raises(KeyError):
+            self.field.to_native(self.OtherEnum.A)
+
+    def test_to_primitive(self):
+        assert self.field.to_primitive(self.SomeEnum.A) == 'A'
+
+        with pytest.raises(TypeError):
+            self.field.to_primitive('A')
+
+    def test_mock(self):
+        class SomeModel(Model):
+            field = EnumType(self.SomeEnum, required=True)
+
+        SomeModel.get_mock_object()
+
+
+class TestBytesType(object):
+    field = BytesType()
+
+    def test_to_native(self):
+        assert self.field.to_native(b'123') == b'123'
+        assert self.field.to_native('V+zSAA==') == b'W\xec\xd2\x00'
+        with pytest.raises(binascii.Error):
+            self.field.to_native('some-non-base64-string')
+
+    def test_to_primitive(self):
+        assert self.field.to_primitive(b'W\xec\xd2\x00') == 'V+zSAA=='
+
+        with pytest.raises(TypeError):
+            self.field.to_primitive('A')
+        with pytest.raises(TypeError):
+            self.field.to_primitive(123)
+
+    def test_mock(self):
+        class SomeModel(Model):
+            field = BytesType(required=True)
+
+        SomeModel.get_mock_object()
+


### PR DESCRIPTION
Add support for `get_mock_object` for custom types `EnumType` and `BytesType`.